### PR TITLE
fix in_addr endianness

### DIFF
--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -59,31 +59,12 @@ impl SockAddr {
 
 impl From<Ipv4Addr> for SockAddr {
     fn from(ip: Ipv4Addr) -> SockAddr {
-        let parts = ip.octets();
+        let octets = ip.octets();
         let mut addr = unsafe { mem::zeroed::<sockaddr_in>() };
 
         addr.sin_family = AF_INET;
         addr.sin_port = 0;
-
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
-        {
-            addr.sin_addr = in_addr {
-                s_addr: ((parts[3] as c_uint) << 24)
-                    | ((parts[2] as c_uint) << 16)
-                    | ((parts[1] as c_uint) << 8)
-                    | (parts[0] as c_uint),
-            };
-        }
-
-        #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
-        {
-            addr.sin_addr = in_addr {
-                s_addr: (parts[0] as c_uint) << 24
-                    | ((parts[1] as c_uint) << 16)
-                    | ((parts[2] as c_uint) << 8)
-                    | (parts[3] as c_uint),
-            };
-        }
+        addr.sin_addr = in_addr { s_addr: u32::from_ne_bytes(octets) };
 
         SockAddr(addr)
     }
@@ -92,26 +73,9 @@ impl From<Ipv4Addr> for SockAddr {
 impl Into<Ipv4Addr> for SockAddr {
     fn into(self) -> Ipv4Addr {
         let ip = self.0.sin_addr.s_addr;
+        let [a, b, c, d] = ip.to_ne_bytes();
 
-        #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
-        {
-            Ipv4Addr::new(
-                ((ip) & 0xff) as u8,
-                ((ip >> 8) & 0xff) as u8,
-                ((ip >> 16) & 0xff) as u8,
-                ((ip >> 24) & 0xff) as u8,
-            )
-        }
-
-        #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
-        {
-            Ipv4Addr::new(
-                ((ip >> 24) & 0xff) as u8,
-                ((ip >> 16) & 0xff) as u8,
-                ((ip >> 8) & 0xff) as u8,
-                ((ip) & 0xff) as u8,
-            )
-        }
+        Ipv4Addr::new(a, b, c, d)
     }
 }
 


### PR DESCRIPTION
follow doc: https://man7.org/linux/man-pages/man7/ip.7.html

```c
struct sockaddr_in {
   sa_family_t    sin_family; /* address family: AF_INET */
   in_port_t      sin_port;   /* port in network byte order */
   struct in_addr sin_addr;   /* internet address */
};

/* Internet address. */
struct in_addr {
   uint32_t       s_addr;     /* address in network byte order */
};
```
`in_addr.s_addr` 在系统里面是使用 大端序保存的，这就是为什么 Rust 的`std::net::Ipv4Addr::octets()` 函数内部使用的是 `.to_ne_bytes()` 而不是 `.to_be_bytes()`。

https://doc.rust-lang.org/nightly/src/std/net/ip.rs.html#364